### PR TITLE
Performance optimisations.

### DIFF
--- a/qmynd.asd
+++ b/qmynd.asd
@@ -45,9 +45,9 @@
        (:module "wire-protocol"
         :serial nil
         :depends-on ("common")
-        :components ((:file "basic-types")
-                     (:file "wire-packet"
-                      :depends-on ("basic-types"))
+        :components ((:file "wire-packet")
+                     (:file "basic-types"
+                      :depends-on ("wire-packet"))
                      (:file "compressed-protocol"
                       :depends-on ("basic-types"))))
        (module "mysql-protocol"

--- a/src/api.lisp
+++ b/src/api.lisp
@@ -12,7 +12,15 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Connection entry-point
-(defun mysql-connect (&key (host "localhost") (port 3306) (username "") (password "") database (ssl :unspecified) ssl-verify)
+(defun mysql-connect (&key
+			(host "localhost")
+			(port 3306)
+			(username "")
+			(password "")
+			database
+			(compress nil)
+			(ssl :unspecified)
+			ssl-verify)
   "Connect to a MySQL over a network (AF_INET) socket and begin the MySQL Handshake.
    Returns a QMYND:MYSQL-CONNECTION object or signals a QMYND:MYSQL-ERROR.
    Accepts the following keyword arguments:
@@ -21,6 +29,7 @@
     USERNAME: User to authenticate as.
     PASSWORD: Password to authenticate with.
     DATABASE: What database to use upon connecting. (default: nil)
+    COMPRESS: Whether or not to use compression. (default: nil).
     SSL: Whether or not to use SSL. (default: :UNSPECIFIED)
                      T - Forces SSL (or error out if it's not available).
                    NIL - Disable SSL, even if it is available.
@@ -35,6 +44,7 @@
                                     :stream (usocket:socket-stream socket)
                                     :default-schema database)))
     (mysql-connect-do-handshake connection username password database
+				:compress compress
                                 :ssl ssl
                                 :ssl-verify ssl-verify)))
 

--- a/src/mysql-protocol/connection.lisp
+++ b/src/mysql-protocol/connection.lisp
@@ -132,11 +132,11 @@
 
 (defmethod mysql-connection-read-packet ((c mysql-base-connection))
   "Read a wire packet from C's stream."
-  (multiple-value-bind (payload seq-id)
+  (multiple-value-bind (stream seq-id)
       (read-wire-packet (mysql-connection-stream c)
                         :expected-sequence-id (mysql-connection-sequence-id c))
     (setf (mysql-connection-sequence-id c) seq-id)
-    payload))
+    stream))
 
 (defmethod mysql-connection-command-init ((c mysql-base-connection) command)
   "Initialize connection for a new command.

--- a/src/mysql-protocol/define-packet.lisp
+++ b/src/mysql-protocol/define-packet.lisp
@@ -227,25 +227,24 @@ Order of Operations:
 
 (defun emit-packet-parser (parser-name constructor-name slot-descriptors)
   (with-gensyms (stream #|local-bind-args|#)
-    `(defun ,parser-name (payload)
-       (flexi-streams:with-input-from-sequence (,stream payload)
-         (let (,@(loop for slotd in slot-descriptors
-                       unless (member (packet-slot-name slotd) done)
-                         when (packet-slot-bind slotd)
-                           collect (packet-slot-name slotd)
-                       collect (packet-slot-name slotd) into done))
-           (block ,parser-name
-             ,@(loop for slotd in slot-descriptors
-                     collect (emit-packet-parser-slot parser-name slotd stream locals)
-                     when (packet-slot-bind slotd)
-                       collect (packet-slot-name slotd) into locals))
-           (,constructor-name
-            ,@(loop for slotd in slot-descriptors
-                    unless (or (packet-slot-transient slotd)
-                               (member (packet-slot-name slotd) done))
-                      collect (kintern "~A" (packet-slot-name slotd))
-                      and collect (packet-slot-name slotd)
-                    collect (packet-slot-name slotd) into done)))))))
+    `(defun ,parser-name (,stream)
+       (let (,@(loop for slotd in slot-descriptors
+                  unless (member (packet-slot-name slotd) done)
+                  when (packet-slot-bind slotd)
+                  collect (packet-slot-name slotd)
+                  collect (packet-slot-name slotd) into done))
+         (block ,parser-name
+           ,@(loop for slotd in slot-descriptors
+                collect (emit-packet-parser-slot parser-name slotd stream locals)
+                when (packet-slot-bind slotd)
+                collect (packet-slot-name slotd) into locals))
+         (,constructor-name
+          ,@(loop for slotd in slot-descriptors
+               unless (or (packet-slot-transient slotd)
+                          (member (packet-slot-name slotd) done))
+               collect (kintern "~A" (packet-slot-name slotd))
+               and collect (packet-slot-name slotd)
+               collect (packet-slot-name slotd) into done))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Entry point macro

--- a/src/mysql-protocol/text-protocol/command-query.lisp
+++ b/src/mysql-protocol/text-protocol/command-query.lisp
@@ -41,11 +41,11 @@
    (flexi-streams:with-output-to-sequence (s)
      (write-byte +mysql-command-query+ s)
      (write-sequence (babel:string-to-octets query-string) s)))
-  (let* ((payload (mysql-read-packet))
-         (tag (aref payload 0)))
+  (let* ((my-stream (mysql-read-packet))
+         (tag       (peek-first-byte my-stream)))
     (if (member tag (list +mysql-response-ok+ +mysql-response-error+))
-        (parse-response payload)
-        (let* ((column-count (parse-column-count payload))
+        (parse-response my-stream)
+        (let* ((column-count (parse-column-count my-stream))
                (column-definitions
 		(coerce
 		 (loop

--- a/src/wire-protocol/compressed-protocol.lisp
+++ b/src/wire-protocol/compressed-protocol.lisp
@@ -39,15 +39,15 @@ uncompressed, but for now using the Compression protocol requires both.
   "Read a compressed packet from STREAM."
   (let (payload
         (pos 0)
-        (compressed-length (read-fixed-length-integer 3 stream))
+        (compressed-length (%read-3-bytes stream))
         (sequence-id (if (= (read-byte stream) expected-sequence-id)
                          (setf expected-sequence-id (mod (1+ expected-sequence-id) 256))
                          (error (make-instance 'unexpected-sequence-id))))
-        (decompressed-length (read-fixed-length-integer 3 stream)))
+        (decompressed-length (%read-3-bytes stream)))
     (assert (plusp compressed-length))
     (setf payload (make-array compressed-length :element-type '(unsigned-byte 8)))
     (loop do (setf pos (read-sequence payload stream :start pos))
-          until (= pos (length payload)))
+       until (= pos (length payload)))
     (values (if (zerop decompressed-length)
                 payload
                 (let ((buffer (make-array decompressed-length :element-type '(unsigned-byte 8))))

--- a/src/wire-protocol/wire-packet.lisp
+++ b/src/wire-protocol/wire-packet.lisp
@@ -33,25 +33,194 @@ each Command Phase.
 
 |#
 
-;;; Functions to read and write wire packets.
-(defun read-wire-packet (stream &key (expected-sequence-id 0))
-  "Read a packet from STREAM."
-  (let ((payload (make-array 0 :element-type '(unsigned-byte 8) :adjustable t))
-        (pos 0))
-    (loop
-      as length = (read-fixed-length-integer 3 stream)
-      as sequence-id = (read-byte stream)
-      if (= sequence-id expected-sequence-id)
-        do (setf expected-sequence-id (mod (1+ expected-sequence-id) 256))
-      else
-        do (error (make-instance 'unexpected-sequence-id))
-      end
-      when (plusp length)
-        do (adjust-array payload (+ pos length))
-           (loop do (setf pos (read-sequence payload stream :start pos))
-                 until (= pos (length payload)))
-      when (< length #xffffff) return (values payload expected-sequence-id))))
+;;;
+;;; The my-packet-stream class actually represents a chunk of the payload at
+;;; a time, and its methods below know how to read from a packet and skip to
+;;; the next chunk as needed.
+;;;
+;;; Each time we switch from a chunk to the next while reading the current
+;;; packet, the slots of the my-stream instance are reset to whatever the
+;;; next chunk properties are, including the chunk contents: we preload the
+;;; payload bytes.
+;;;
+;;; The methods are implemented as functions because we care enough about
+;;; performances here to want to avoid the cost of CLOS dispatching.
+;;;
+;;; The main entry point to read data from the raw stream is
+;;; read-wire-packet, which prepares a packet by reading its first chunk.
+;;;
+;;; The define-packet API and basic types implementation then fetch data
+;;; from the stream by using the following low-level functions:
+;;;
+;;;  - read-my-byte
+;;;  - peek-my-byte
+;;;  - read-my-sequence
+;;;  - read-all-remaining-bytes
+;;;
+;;; Higher level functions such as read-fixed-length-integer or
+;;; read-length-encoded-integer are defined in basic-types.lisp and build on
+;;; this low-level API.
+;;;
+(defconstant +max-packet-length+ #xffffff)
 
+(defstruct (my-packet-stream (:conc-name my-))
+  (source  nil :type (or null stream))
+  (payload nil :type (or null (simple-array (unsigned-byte 8) *)))
+  (seq-id  0   :type (integer 0 255))
+  (len     0   :type (integer 0 #xffffff))
+  (pos     0   :type (integer 0 #xffffff)))
+
+(defmethod print-object ((stream my-packet-stream) out)
+  (print-unreadable-object (stream out :type t)
+    (format out "~d/~d [~d]"
+            (if (slot-boundp stream 'pos) (my-pos stream) "-")
+            (if (slot-boundp stream 'len) (my-len stream) "-")
+            (my-seq-id stream))))
+
+(defun read-wire-packet (stream &key (expected-sequence-id 0))
+  "Instanciate a my-packet-stream object and read some meta-data about it."
+  (let ((my-stream (make-my-packet-stream :source stream
+                                          :seq-id expected-sequence-id)))
+    ;; the next chunk is going to be the first one
+    (prepare-next-chunk my-stream)))
+
+;;;
+;;; Low level protocol handling
+;;;
+(declaim (inline %read-3-bytes))
+
+(defun %read-3-bytes (stream)
+  "Internal for wire protocol use only."
+  (declare (type stream stream))
+  ;; As we don't have a proper my-packet-stream yet, we can't use
+  ;; the usual read-3-bytes-integer implementation. We also know we
+  ;; are readding unsigned integer...
+  (let ((byte-1 (read-byte stream))
+        (byte-2 (read-byte stream))
+        (byte-3 (read-byte stream)))
+    (declare (type (unsigned-byte 8) byte-1 byte-2 byte-3))
+    (logior (ash byte-3 16) (ash byte-2  8) byte-1)))
+
+(defun prepare-next-chunk (my-stream)
+  "Prepare reading from a new packet from our source stream."
+  (let ((expected-sequence-id (my-seq-id my-stream)))
+    (setf (my-len my-stream)     (%read-3-bytes (my-source my-stream))
+          (my-seq-id my-stream)  (read-byte (my-source my-stream)))
+
+    (assert (= expected-sequence-id (my-seq-id my-stream))
+            () 'unexpected-sequence-id)
+
+    ;; prefetch this chunk of data, and reset the position
+    (setf (my-payload my-stream)
+          (read-whole-chunk (my-len my-stream) my-stream)
+
+          (my-pos my-stream) 0)
+
+    (setf (my-seq-id my-stream) (logand (1+ expected-sequence-id) #xFF))
+    (values my-stream (my-seq-id my-stream))))
+
+;;;
+;;; Streaming API on top of the chunked packets protocol, automatically
+;;; switch to next chunk as we read from the current packet.
+;;;
+(declaim (inline maybe-read-next-chunk))
+(defun maybe-read-next-chunk (stream &optional eof-error-p eof-value)
+  "Check if we are at the end of the packet, or if we need to read from the
+   next chunk from the network within the same \"logical\" packet."
+  (when (= (my-pos stream) (my-len stream))
+    (if (< (my-len stream) +max-packet-length+)
+      ;; no extra packet was needed
+      (if eof-error-p (signal 'end-of-file) eof-value)
+
+      ;; we reached the end of a +max-packet-length+ packet and need to read
+      ;; from the next one now
+      (progn
+        (prepare-next-chunk stream)
+        ;; we have to care about the connection sequence id here
+        (setf (mysql-connection-sequence-id *mysql-connection*)
+              (my-seq-id stream))))))
+
+(defun read-my-byte (stream &optional eof-error-p eof-value)
+  "Read a single byte from STREAM."
+  (declare (type my-packet-stream stream))
+
+  ;; support for the peek-my-byte API
+  (maybe-read-next-chunk stream eof-error-p eof-value)
+
+  ;; now read a single byte from our source
+  (prog1
+      (aref (my-payload stream) (my-pos stream))
+    (incf (my-pos stream))))
+
+(defun peek-first-byte (stream)
+  "Get the first byte in this stream's chunk."
+  (aref (my-payload stream) 0))
+
+(defun read-my-sequence (sequence stream)
+  "Copy data from the STREAM into SEQUENCE."
+  (declare (type my-packet-stream stream)
+           (type (simple-array (unsigned-byte 8) (*)) sequence))
+
+  (if (<= (+ (length sequence) (my-pos stream)) (my-len stream))
+      ;; we already have the bytes we're asked for, just grab'em
+      (progn
+        (replace sequence (my-payload stream) :start2 (my-pos stream))
+        (incf (my-pos stream) (length sequence)))
+
+      ;; in that case we're going to cross a packet boundary, so read one
+      ;; byte at a time, read-my-byte knows how to cross boundaries.
+      (loop
+         for pos fixnum from 0 below (length sequence)
+         do (setf (aref sequence pos) (read-my-byte stream))
+         finally (return pos))))
+
+;;;
+;;; API to finish reading all remaining chunks of a packet
+;;;
+(defun concatenate-vectors (length vectors)
+  "Given a list of VECTORS containing LENGTH octets in total, return a
+   single vector containing the same octets in the same order."
+  (if (= 1 (length vectors))
+      (first vectors)
+      (let ((vector (make-array length :element-type '(unsigned-byte 8))))
+        (loop for start = 0 then (+ start (length sub-vector))
+           for sub-vector in vectors
+           do (replace vector
+                       (the (simple-array (unsigned-byte 8) (*))
+                            sub-vector)
+                       :start1 start))
+        vector)))
+
+(defun read-whole-chunk (length stream)
+  "Read LENGTH bytes from STREAM and return an array of them."
+  (declare (type my-packet-stream stream))
+  (let ((vector (make-array length :element-type '(unsigned-byte 8))))
+    (loop for pos = 0 then (read-sequence vector (my-source stream) :start pos)
+       until (= pos length))
+    (incf (my-pos stream) length)
+    vector))
+
+(defun read-all-remaining-bytes (stream)
+  "Copy the rest of the whole data set into an array and return it."
+  (declare (type my-packet-stream stream))
+
+  (loop
+     for length = (- (my-len stream) (my-pos stream))
+
+     when (plusp length)
+     collect (read-whole-chunk length stream) into vectors
+     and sum length into total-length
+
+     ;; we might read less than the full length of the current chunk, but we
+     ;; only get to stop when the current chunk total length is less than
+     ;; +max-packet-length+
+     if (< (my-len stream) +max-packet-length+)
+     return (concatenate-vectors total-length vectors)
+     else do (prepare-next-chunk stream)))
+
+;;;
+;;; Write bytes to the wire socket, as chunked packets.
+;;;
 (defun write-wire-packet (stream payload &key (sequence-id 0))
   "Write PAYLOAD to STREAM as one or more packets."
   (loop


### PR DESCRIPTION
Please find in this Pull Request a series of improvements to the handling of the chunked packet protocol implementation of qmynd. Simple testing made with the sakila database and pgloader, as in http://tapoueh.org/blog/2013/11/12-migrating-sakila, shows the new code to be twice as fast as the current one, when disabling compression over a local connection.

The series shows a first idea where the payload was still eagerly fetched. Much better performances can be obtained by simply implementing a chunked stream directly as in the final patch.

Please consider merging the new code, it would enable be to use qmynd in pgloader while not paying too high a price for a better model of memory management (one row at a time) when compared to cl-mysql.
