### PR TITLE
also support VARBINARY columns

### DIFF
--- a/src/mysql-protocol/response-result-set.lisp
+++ b/src/mysql-protocol/response-result-set.lisp
@@ -183,7 +183,8 @@
            octets)
 
           ;; binary strings are strings with binary collations...
-          ((and (= column-type +mysql-type-string+)
+          ((and (member column-type (list +mysql-type-string+
+                                          +mysql-type-var-string+))
                 (= (column-definition-v41-packet-cs-coll column-definition)
                    +mysql-cs-coll-binary+))
            octets)


### PR DESCRIPTION
qitab/qmynd@b48cd4e41f76e7f930b1efeedbe04c4efc86c52d added support for BINARY columns; this just extends it to also handle VARBINARY.