### PR TITLE
mysql-local-connection: add implementation for ECL

### DIFF
--- a/src/mysql-protocol/connection.lisp
+++ b/src/mysql-protocol/connection.lisp
@@ -79,7 +79,7 @@
   (usocket:socket-close (mysql-connection-socket c))
   (setf (mysql-connection-connected *mysql-connection*) nil))
 
-#+(or ccl sbcl)
+#+(or ccl sbcl ecl)
 (progn
 
   (defclass mysql-local-connection (mysql-base-connection)
@@ -90,7 +90,8 @@
   (defmethod mysql-connection-close-socket ((c mysql-local-connection))
     (let ((socket (mysql-connection-socket c)))
       #+ccl (ccl::close socket)
-      #+sbcl (sb-bsd-sockets:socket-close socket)
+      #+(or sbcl ecl)
+      (sb-bsd-sockets:socket-close socket)
       )
     (setf (mysql-connection-connected *mysql-connection*) nil))
 

--- a/src/pkgdcl.lisp
+++ b/src/pkgdcl.lisp
@@ -69,7 +69,7 @@
    #:*mysql-encoding*
    ;; Connections
    #:mysql-connect
-   #+(or ccl sbcl)
+   #+(or ccl sbcl ecl)
    #:mysql-local-connect
    #:mysql-disconnect
    #:mysql-connection-has-status


### PR DESCRIPTION
ECL shares sb-bsd-sockets api with SBCL - this commit adds in
appropriate places ecl to conditional features.

Signed-off-by: Daniel Kochmański <daniel@turtleware.eu>