### PR TITLE
Add utf8mb4_0900_ai_ci support

### DIFF
--- a/src/common/charsets.lisp
+++ b/src/common/charsets.lisp
@@ -273,5 +273,6 @@
 ;;; 252 is NOT USED
 ;;; 253 is NOT USED
 (defconstant +mysql-cs-coll-utf8mb3-general-cs+        254)
+(defconstant +mysql-cs-coll-utf8mb4-0900-ai-ci+        255)
 
 )            ;eval-when

--- a/src/common/misc.lisp
+++ b/src/common/misc.lisp
@@ -92,6 +92,7 @@
     ;; (#. +mysql-cs-coll-koi8r-binary+            :unknown)
     ;; (#. +mysql-cs-coll-koi8u-binary+            :unknown)
     (#. +mysql-cs-coll-utf8-tolower-ci+          :utf-8)
+    (#. +mysql-cs-coll-utf8mb4-0900-ai-ci+       :utf-8)
     (#. +mysql-cs-coll-latin2-binary+            :iso-8859-2)
     (#. +mysql-cs-coll-latin5-binary+            :iso-8859-5)
     (#. +mysql-cs-coll-latin7-binary+            :iso-8859-7)


### PR DESCRIPTION
Add utf8mb4_0900_ai_ci support as utf8mb4_0900_ai_ci is the default collation in mysql 8.0.1+.
Quote from the 8.0.1 [release notes](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html#mysqld-8-0-1-charset):
> The default value of the collation_server and collation_database system variables has changed from latin1_swedish_ci to utf8mb4_0900_ai_ci.
