### PR TITLE
Add utf8mb4_0900_as_cs support

### DIFF
--- a/src/common/charsets.lisp
+++ b/src/common/charsets.lisp
@@ -274,5 +274,6 @@
 ;;; 253 is NOT USED
 (defconstant +mysql-cs-coll-utf8mb3-general-cs+        254)
 (defconstant +mysql-cs-coll-utf8mb4-0900-ai-ci+        255)
+(defconstant +mysql-cs-coll-utf8mb4-0900-as-cs+        278)
 
 )            ;eval-when

--- a/src/common/misc.lisp
+++ b/src/common/misc.lisp
@@ -93,6 +93,7 @@
     ;; (#. +mysql-cs-coll-koi8u-binary+            :unknown)
     (#. +mysql-cs-coll-utf8-tolower-ci+          :utf-8)
     (#. +mysql-cs-coll-utf8mb4-0900-ai-ci+       :utf-8)
+    (#. +mysql-cs-coll-utf8mb4-0900-as-cs+       :utf-8)
     (#. +mysql-cs-coll-latin2-binary+            :iso-8859-2)
     (#. +mysql-cs-coll-latin5-binary+            :iso-8859-5)
     (#. +mysql-cs-coll-latin7-binary+            :iso-8859-7)


### PR DESCRIPTION
Add utf8mb4_0900_as_cs support, as it can be used as an accent-sensitive, case-sensitive collation for a couple of languages as described in the MySQL documentation: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html#mysqld-8-0-1-charset