### PR TITLE
Add support for utf8mb4_0900_bin collation

### DIFF
--- a/src/common/charsets.lisp
+++ b/src/common/charsets.lisp
@@ -274,5 +274,7 @@
 ;;; 253 is NOT USED
 (defconstant +mysql-cs-coll-utf8mb3-general-cs+        254)
 (defconstant +mysql-cs-coll-utf8mb4-0900-ai-ci+        255)
+;;; 256-308 is NOT USED
+(defconstant +mysql-cs-coll-utf8mb4-0900-bin+          309)
 
 )            ;eval-when

--- a/src/common/misc.lisp
+++ b/src/common/misc.lisp
@@ -93,6 +93,7 @@
     ;; (#. +mysql-cs-coll-koi8u-binary+            :unknown)
     (#. +mysql-cs-coll-utf8-tolower-ci+          :utf-8)
     (#. +mysql-cs-coll-utf8mb4-0900-ai-ci+       :utf-8)
+    (#. +mysql-cs-coll-utf8mb4-0900-bin+         :utf-8)
     (#. +mysql-cs-coll-latin2-binary+            :iso-8859-2)
     (#. +mysql-cs-coll-latin5-binary+            :iso-8859-5)
     (#. +mysql-cs-coll-latin7-binary+            :iso-8859-7)


### PR DESCRIPTION
Add support for the utf8mb4_0900_bin collation, added in MySQL 8.0.17.

The id can be verified by calling this on a recent MySQL server.

```
MySQL [xxxxxxxx_staging]> show collation where id = 309;
+------------------+---------+-----+---------+----------+---------+---------------+
| Collation        | Charset | Id  | Default | Compiled | Sortlen | Pad_attribute |
+------------------+---------+-----+---------+----------+---------+---------------+
| utf8mb4_0900_bin | utf8mb4 | 309 |         | Yes      |       1 | NO PAD        |
+------------------+---------+-----+---------+----------+---------+---------------+
1 row in set (0.051 sec)
```